### PR TITLE
BUGFIX: Shorten Embed Field

### DIFF
--- a/bot/bot_responses.py
+++ b/bot/bot_responses.py
@@ -21,7 +21,7 @@ def previous_feedback_submission_message(prev_feedback_metadata: MessageResponse
     """ Embedded response for .last"""
     embed = discord.Embed(title="Previous Feedback Submission", description="By: " + prev_feedback_metadata.author,
                           color=Color.green())
-    embed.add_field(name="Original Message", value=prev_feedback_metadata.content, inline=False)
+    embed.add_field(name="Original Message", value=prev_feedback_metadata.content[0:997] + "...", inline=False)
     embed.add_field(name="Link to Message", value=prev_feedback_metadata.jump_url, inline=False)
     return embed
 

--- a/bot/main.py
+++ b/bot/main.py
@@ -62,6 +62,7 @@ async def on_message(message: Message):
     # Someone wants to know what the last feedback is.
     if '.last' in message.content:
         last_feedback_info = await last_feedback(message)
+        logger.info('last feedback message length: {}'.format(len(last_feedback_info.content)))
         await message.channel.send(embed=previous_feedback_submission_message(last_feedback_info))
 
     # Some general info about this bot and the commands available.


### PR DESCRIPTION
The following error appeared:
```
discord.errors.HTTPException: 400 Bad Request (error code: 50035): Invalid Form Body
In embed.fields.0.value: Must be 1024 or fewer in length.
```
Solution:
- Limit the message size and append a trailing ellipsis. Decided to go with 1000 character total limit for the embed message. Fixes `.last` and last_feedback being broken when message is too long.